### PR TITLE
Dynamic FOV Changing with toggle variable in .ini

### DIFF
--- a/FF7RebirthFix.ini
+++ b/FF7RebirthFix.ini
@@ -12,6 +12,9 @@ Global = false
 ; Adjust "Multiplier" to increase or decrease FOV.
 ; i.e for 20% higher FOV, set "Multiplier = 1.2"
 Multiplier = 1
+; Set "DynamicChanger" to true to enable the FOV changer
+; FOV Multiplier is controllable in-game using Keypad 1-9 for "Multiplier" values 0.6-1.4. Keypad * is to toggle "Global".
+DynamicChanger = true
 
 [Subtitles]
 ; Adjust "Size" to increase or decrease the size of the subtitles. i.e for subtitles that are 25% smaller, set "Size" to 0.75

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1194,7 +1194,7 @@ LRESULT CALLBACK LowLevelKeyboardProc( int nCode, WPARAM wParam, LPARAM lParam )
             if (!(pKey->flags & KF_REPEAT))
             {
                 int keyIndex = vk - VK_NUMPAD1;
-                fFOVMulti = 0.6f + (keyIndex + 1) * 0.1f;
+                fFOVMulti = 0.6f + (keyIndex) * 0.1f;
 
 				spdlog::info( "FOV multiplier set to {:.1f}", fFOVMulti );
 			}


### PR DESCRIPTION
Inspired by discussion in issue #4

Adds a dynamic FOV changer that is enabled through the .ini and is controlled with the keypad.

* Added a new config option `DynamicChanger` to enable a dynamic FOV changer. This allows in-game control of the FOV multiplier using Keypad 1-9 for the FOV multiplier and Keypad * to toggle `bGlobalFOVMulti`. Keypad 1-9 corresponds to `fFOVMulti` values 0.6-1.4.
* Added the `FOVChanger` function (called by `Main`), which creates a low-level keyboard hook and message loop. The hook handles key presses for changing the FOV multiplier and toggling the global FOV bool. The hook and loop are only created if `DynamicChanger` is true in the config.
* FOV functions were made global in `AspectRatioFOV` so they could be reused and reset in `LowLevelKeyboardProc`.